### PR TITLE
Add luaurc

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -1,0 +1,6 @@
+{
+	"languageMode": "strict",
+	"lint": {
+        "MultiLineStatement": false
+    }
+}


### PR DESCRIPTION
Add a luaurc file to make every luau file use strict typechecking, whilst this does create a ton of type errors. Those should be fixed, because it'll help ensure safety with the library by being able to catch issues ahead of time.