### PR TITLE
Primarily constants related - lengthy description

### DIFF
--- a/ProfileStore.luau
+++ b/ProfileStore.luau
@@ -187,6 +187,20 @@ local Constants: {[ConstantName]: number} = {
 
 }
 
+local LOG_PREFIX = "[ProfileStore]:"
+
+local function LogInfo(...)
+	print(LOG_PREFIX, ...)
+end
+
+local function LogWarn(...)
+	warn(LOG_PREFIX, ...)
+end
+
+local function LogError(...)
+	error(LOG_PREFIX, ...)
+end
+
 ----- Dependencies -----
 
 -- local Util = require(game.ReplicatedStorage.Shared.Util)
@@ -263,7 +277,7 @@ local Signal do
 	function SignalClass:Connect(listener: (...any) -> ())
 
 		if type(listener) ~= "function" then
-			error(`[{script.Name}]: \"listener\" must be a function; Received {typeof(listener)}`)
+			LogError(`Invalid type for parameter "listener" was provided - expected function, got "{typeof(listener)}"`)
 		end
 
 		local connection = {
@@ -429,13 +443,13 @@ local function ReconcileTable(target, template)
 end
 
 local function RegisterError(error_message, store_name, profile_key) -- Called when a DataStore API call errors
-	warn(`[{script.Name}]: DataStore API error (STORE:{store_name}; KEY:{profile_key}) - {tostring(error_message)}`)
+	LogWarn(`DataStore API error (STORE:{store_name}; KEY:{profile_key}) - {tostring(error_message)}`)
 	table.insert(IssueQueue, os.clock()) -- Adding issue time to queue
 	OnError:Fire(tostring(error_message), store_name, profile_key)
 end
 
 local function RegisterOverwrite(store_name, profile_key) -- Called when a corrupted profile is loaded
-	warn(`[{script.Name}]: Invalid profile was overwritten (STORE:{store_name}; KEY:{profile_key})`)
+	LogWarn(`Invalid profile was overwritten (STORE:{store_name}; KEY:{profile_key})`)
 	OnOverwrite:Fire(store_name, profile_key)
 end
 
@@ -616,7 +630,7 @@ local function UpdateAsync(profile_store, profile_key, transform_params, is_user
 					end)
 
 					if success == false and type(error_message) == "string" and string.find(error_message, "not valid") ~= nil then
-						warn(`[{script.Name}]: Passed version argument is not valid; Traceback:\n` .. debug.traceback())
+						LogWarn(`Passed version argument is not valid; Traceback:\n` .. debug.traceback())
 					end
 
 				else
@@ -716,7 +730,7 @@ end
 local function SaveProfileAsync(profile, is_ending_session, is_overwriting, last_save_reason)
 
 	if type(profile.Data) ~= "table" then
-		error(`[{script.Name}]: Developer code likely set "Profile.Data" to a non-table value! (STORE:{profile.ProfileStore.Name}; KEY:{profile.Key})`)
+		LogError(`Profile.Data was set to invalid type "{typeof(profile.Data)}" - expected table. Aborting save (STORE:{profile.ProfileStore.Name}; KEY:{profile.Key})`)
 	end
 
 	profile.OnSave:Fire()
@@ -1104,7 +1118,7 @@ end
 function Profile:AddUserId(user_id) -- Associates user_id with profile (GDPR compliance)
 
 	if type(user_id) ~= "number" or user_id % 1 ~= 0 then
-		warn(`[{script.Name}]: Invalid UserId argument for :AddUserId() ({tostring(user_id)}); Traceback:\n` .. debug.traceback())
+		LogWarn(`Invalid UserId argument for :AddUserId() ({tostring(user_id)}); Traceback:\n` .. debug.traceback())
 		return
 	end
 
@@ -1121,7 +1135,7 @@ end
 function Profile:RemoveUserId(user_id) -- Unassociates user_id with profile (safe function)
 
 	if type(user_id) ~= "number" or user_id % 1 ~= 0 then
-		warn(`[{script.Name}]: Invalid UserId argument for :RemoveUserId() ({tostring(user_id)}); Traceback:\n` .. debug.traceback())
+		LogWarn(`Invalid UserId argument for :RemoveUserId() ({tostring(user_id)}); Traceback:\n` .. debug.traceback())
 		return
 	end
 
@@ -1136,7 +1150,7 @@ end
 function Profile:SetAsync() -- Saves the profile to the DataStore and removes the session lock
 
 	if self.view_mode ~= true then
-		error(`[{script.Name}]: :SetAsync() can only be used in view mode`)
+		LogError(`:SetAsync() can only be used in view mode`)
 	end
 
 	SaveProfileAsync(self, nil, true)
@@ -1146,7 +1160,7 @@ end
 function Profile:MessageHandler(fn)
 
 	if type(fn) ~= "function" then
-		error(`[{script.Name}]: fn argument is not a function`)
+		LogError(`Invalid type for parameter "fn" was provided - expected function, got "{typeof(fn)}"`)
 	end
 
 	if self.view_mode ~= true and self:IsActive() ~= true then
@@ -1180,11 +1194,11 @@ end
 function Profile:Save()
 	
 	if self.view_mode == true then
-		error(`[{script.Name}]: Can't save profile in view mode; Should you be calling :SetAsync() instead?`)
+		LogError("Can't save profile in view mode - should you be calling :SetAsync() instead?")
 	end
 	
 	if self:IsActive() == false then
-		warn(`[{script.Name}]: Attempted saving an inactive profile (STORE:{self.ProfileStore.Name}; KEY:{self.Key});`
+		LogWarn(`Attempted saving an inactive profile (STORE:{self.ProfileStore.Name}; KEY:{self.Key});`
 			.. ` Traceback:\n` .. debug.traceback())
 		return
 	end
@@ -1213,23 +1227,23 @@ ProfileStore.__index = ProfileStore
 function ProfileStore.SetConstant(name, value)
 
 	if table.isfrozen(Constants) then
-		error("[{script.Name}]: Attempted to set constants after calling ProfileStore.New() - constants must be edited prior to initialization")
+		LogError("Attempted to set constants after calling ProfileStore.New() - constants must be edited prior to initialization")
 	end
 
 	if type(name) ~= "string" then
-		error(`[{script.Name}]: Invalid type for parameter "name" was provided - expected string, got "{typeof(name)}"`)
+		LogError(`Invalid type for parameter "name" was provided - expected string, got "{typeof(name)}"`)
 	end
 
 	if Constants[name] == nil then
-		error(`[{script.Name}]: Invalid constant name "{name}" was provided`)
+		LogError(`Invalid constant "{name}" was provided`)
 	end
 
 	if type(value) ~= "number" then
-		error(`[{script.Name}]: Invalid type for parameter "value" was provided - expected number, got "{typeof(value)}"`)
+		LogError(`Invalid type for parameter "value" was provided - expected number, got "{typeof(value)}"`)
 	end
 
 	if value < 0 then
-		error(`[{script.Name}]: Attempted to set value of constant "{name}" below 0 - value must not be negative`)
+		LogError(`Attempted to set value of constant "{name}" below 0 - value must not be negative`)
 	end
 
 	Constants[name] = value
@@ -1240,7 +1254,7 @@ function ProfileStore.SetConstants(constants)
 	
 	local tmp = typeof(constants)
 	if tmp ~= "table" then
-		error(`[{script.Name}]: Invalid type for parameter "constants" was provided - expected table, got "{tmp}"{tmp == "string" and ". Should you be calling .SetConstant() instead?"}`)
+		LogError(`Invalid type for parameter "constants" was provided - expected table, got "{tmp}"{tmp == "string" and ". Should you be calling .SetConstant() instead?"}`)
 	end
 
 	for k, v in constants do
@@ -1268,15 +1282,15 @@ function ProfileStore.New(store_name, template)
 	Constants = table.freeze(Constants)
 
 	if type(store_name) ~= "string" then
-		error(`[{script.Name}]: Invalid or missing "store_name"`)
+		LogError(`Invalid type for parameter "store_name" was provided - expected string, got "{typeof(store_name)}"`)
 	elseif string.len(store_name) == 0 then
-		error(`[{script.Name}]: store_name cannot be an empty string`)
+		LogError(`Parameter "store_name" is too short - must be at least 1 character`)
 	elseif string.len(store_name) > 50 then
-		error(`[{script.Name}]: store_name is too long`)
+		LogError(`Parameter "store_name" is too long - cannot exceed 50 characters, was {string.len(store_name)}`)
 	end
 
 	if type(template) ~= "table" then
-		error(`[{script.Name}]: Invalid template argument`)
+		LogError(`Invalid type for parameter "template" was provided - expected table, got "{typeof(template)}"`)
 	end
 
 	local self
@@ -1353,19 +1367,19 @@ end
 function ProfileStore:StartSessionAsync(profile_key, params)
 
 	local is_mock = ReadMockFlag()
-
+	
 	if type(profile_key) ~= "string" then
-		error(`[{script.Name}]: profile_key must be a string`)
+		LogError(`Invalid type for parameter "profile_key" was provided - expected string, got "{typeof(profile_key)}"`)
 	elseif string.len(profile_key) == 0 then
-		error(`[{script.Name}]: Invalid profile_key`)
+		LogError(`Parameter "profile_key" is too short - must be at least 1 character`)
 	elseif string.len(profile_key) > 50 then
-		error(`[{script.Name}]: profile_key is too long`)
+		LogError(`Parameter "profile_key" is too long - cannot exceed 50 characters, was {string.len(profile_key)}`)
 	end
-	
+
 	if params ~= nil and type(params) ~= "table" then
-		error(`[{script.Name}]: Invalid params`)
+		LogError(`Invalid type for parameter "params" was provided - expected table, got "{typeof(params)}"`)
 	end
-	
+
 	params = params or {}
 
 	if ProfileStore.IsClosing == true then
@@ -1377,7 +1391,7 @@ function ProfileStore:StartSessionAsync(profile_key, params)
 	local session_token = SessionToken(self.Name, profile_key, is_mock)
 
 	if ActiveSessionCheck[session_token] ~= nil then
-		error(`[{script.Name}]: Profile (STORE:{self.Name}; KEY:{profile_key}) is already loaded in this session`)
+		LogError(`Profile (STORE:{self.Name}; KEY:{profile_key}) is already loaded in this session - are you calling :StartSessionAsync() twice or forgetting to use :EndSession() after a player leaves?`)
 	end
 
 	ActiveProfileLoadJobs = ActiveProfileLoadJobs + 1
@@ -1641,15 +1655,15 @@ function ProfileStore:MessageAsync(profile_key, message)
 	local is_mock = ReadMockFlag()
 
 	if type(profile_key) ~= "string" then
-		error(`[{script.Name}]: profile_key must be a string`)
+		LogError(`Invalid type for parameter "profile_key" was provided - expected string, got "{typeof(profile_key)}"`)
 	elseif string.len(profile_key) == 0 then
-		error(`[{script.Name}]: Invalid profile_key`)
+		LogError(`Parameter "profile_key" is too short - must be at least 1 character`)
 	elseif string.len(profile_key) > 50 then
-		error(`[{script.Name}]: profile_key is too long`)
+		LogError(`Parameter "profile_key" is too long - cannot exceed 50 characters, was {string.len(profile_key)}`)
 	end
 
 	if type(message) ~= "table" then
-		error(`[{script.Name}]: message must be a table`)
+		LogError(`Invalid type for parameter "message" was provided - expected table, got "{typeof(message)}"`)
 	end
 
 	if ProfileStore.IsClosing == true then
@@ -1739,11 +1753,11 @@ function ProfileStore:GetAsync(profile_key, version)
 	local is_mock = ReadMockFlag()
 
 	if type(profile_key) ~= "string" then
-		error(`[{script.Name}]: profile_key must be a string`)
+		LogError(`Invalid type for parameter "profile_key" was provided - expected string, got "{typeof(profile_key)}"`)
 	elseif string.len(profile_key) == 0 then
-		error(`[{script.Name}]: Invalid profile_key`)
+		LogError(`Parameter "profile_key" is too short - must be at least 1 character`)
 	elseif string.len(profile_key) > 50 then
-		error(`[{script.Name}]: profile_key is too long`)
+		LogError(`Parameter "profile_key" is too long - cannot exceed 50 characters, was {string.len(profile_key)}`)
 	end
 
 	if ProfileStore.IsClosing == true then
@@ -1816,8 +1830,12 @@ function ProfileStore:RemoveAsync(profile_key)
 
 	local is_mock = ReadMockFlag()
 
-	if type(profile_key) ~= "string" or string.len(profile_key) == 0 then
-		error(`[{script.Name}]: Invalid profile_key`)
+	if type(profile_key) ~= "string" then
+		LogError(`Invalid type for parameter "profile_key" was provided - expected string, got "{typeof(profile_key)}"`)
+	elseif string.len(profile_key) == 0 then
+		LogError(`Parameter "profile_key" is too short - must be at least 1 character`)
+	elseif string.len(profile_key) > 50 then
+		LogError(`Parameter "profile_key" is too long - cannot exceed 50 characters, was {string.len(profile_key)}`)
 	end
 
 	if ProfileStore.IsClosing == true then
@@ -1930,7 +1948,7 @@ function ProfileVersionQuery:NextAsync()
 	if self.is_mock == true or DataStoreState ~= "Access" then
 		if IsStudio == true and WarnAboutVersionQueryOnce == false then
 			WarnAboutVersionQueryOnce = true
-			warn(`[{script.Name}]: :VersionQuery() is not supported in mock mode!`)
+			LogWarn(`:VersionQuery() is not supported in mock mode!`)
 		end
 		return nil -- Silently fail :NextAsync() requests
 	end
@@ -1968,7 +1986,7 @@ function ProfileVersionQuery:NextAsync()
 			end)
 
 			if list_success == false or self.query_pages == nil then
-				warn(`[{script.Name}]: Version query fail - {tostring(error_message)}`)
+				LogWarn(`Version query fail - {tostring(error_message)}`)
 				self.query_failure = true
 			end
 
@@ -2047,23 +2065,30 @@ function ProfileStore:VersionQuery(profile_key, sort_direction, min_date, max_da
 
 	local is_mock = ReadMockFlag()
 
-	if type(profile_key) ~= "string" or string.len(profile_key) == 0 then
-		error(`[{script.Name}]: Invalid profile_key`)
+	if type(profile_key) ~= "string" then
+		LogError(`Invalid type for parameter "profile_key" was provided - expected string, got "{typeof(profile_key)}"`)
+	elseif string.len(profile_key) == 0 then
+		LogError(`Parameter "profile_key" is too short - must be at least 1 character`)
+	elseif string.len(profile_key) > 50 then
+		LogError(`Parameter "profile_key" is too long - cannot exceed 50 characters, was {string.len(profile_key)}`)
 	end
 
 	-- Type check:
 
-	if sort_direction ~= nil and (typeof(sort_direction) ~= "EnumItem"
-		or sort_direction.EnumType ~= Enum.SortDirection) then
-		error(`[{script.Name}]: Invalid sort_direction ({tostring(sort_direction)})`)
+	if sort_direction ~= nil then
+		if typeof(sort_direction) ~= "EnumItem" then
+			LogError(`Invalid type for parameter "sort_direction" was provided - expected EnumItem, got "{typeof(sort_direction)}"`)
+		elseif typeof(sort_direction) == "EnumItem" and sort_direction.EnumType ~= Enum.SortDirection then
+			LogError(`Invalid EnumType for parameter "sort_direction" was provided - expected Enum.SortDirection, got "{sort_direction.EnumType}"`);
+		end
 	end
 
 	if min_date ~= nil and typeof(min_date) ~= "DateTime" and typeof(min_date) ~= "number" then
-		error(`[{script.Name}]: Invalid min_date ({tostring(min_date)})`)
+		LogError(`Invalid type for parameter "min_date" was provided - expected DateTime or number, got "{typeof(min_date)}"`)
 	end
 
 	if max_date ~= nil and typeof(max_date) ~= "DateTime" and typeof(max_date) ~= "number" then
-		error(`[{script.Name}]: Invalid max_date ({tostring(max_date)})`)
+		LogError(`Invalid type for parameter "max_date" was provided - expected DateTime or number, got "{typeof(max_date)}"`)
 	end
 
 	min_date = typeof(min_date) == "DateTime" and min_date.UnixTimestampMillis or min_date
@@ -2089,7 +2114,7 @@ if IsStudio == true then
 		local no_internet_access = status == false and string.find(message, "ConnectFail", 1, true) ~= nil
 
 		if no_internet_access == true then
-			warn(`[{script.Name}]: No internet access - check your network connection`)
+			LogWarn(`No internet access - check your network connection`)
 		end
 
 		if status == false and
@@ -2098,10 +2123,10 @@ if IsStudio == true then
 				no_internet_access == true) then -- No internet access
 
 			new_state = if no_internet_access == true then "NoInternet" else "NoAccess"
-			print(`[{script.Name}]: Roblox API services unavailable - data will not be saved`)
+			LogInfo(`Roblox API services unavailable - data will not be saved`)
 		else
 			new_state = "Access"
-			print(`[{script.Name}]: Roblox API services available - data will be saved`)
+			LogInfo(`Roblox API services available - data will be saved`)
 		end
 
 		DataStoreState = new_state
@@ -2165,7 +2190,7 @@ RunService.Heartbeat:Connect(function()
 			ProfileStore.IsCriticalState = true
 			ProfileStore.OnCriticalToggle:Fire(true)
 			CriticalStateStart = os.clock()
-			warn(`[{script.Name}]: Entered critical state`)
+			LogWarn(`Entered critical state`)
 		end
 	else
 		if #IssueQueue >= Constants.CRITICAL_STATE_ERROR_COUNT then
@@ -2173,7 +2198,7 @@ RunService.Heartbeat:Connect(function()
 		elseif os.clock() - CriticalStateStart > Constants.CRITICAL_STATE_EXPIRE then
 			ProfileStore.IsCriticalState = false
 			ProfileStore.OnCriticalToggle:Fire(false)
-			warn(`[{script.Name}]: Critical state ended`)
+			LogWarn(`Critical state ended`)
 		end
 	end
 

--- a/ProfileStore.luau
+++ b/ProfileStore.luau
@@ -167,18 +167,22 @@ MAD STUDIO (by loleris)
 		
 --]]
 
-local AUTO_SAVE_PERIOD = 300 -- (Seconds) Time between when changes to a profile are saved to the DataStore
-local LOAD_REPEAT_PERIOD = 10 -- (Seconds) Time between successive profile reads when handling a session conflict
-local FIRST_LOAD_REPEAT = 5 -- (Seconds) Time between first and second profile read when handling a session conflict
-local SESSION_STEAL = 40 -- (Seconds) Time until a session conflict is resolved with the waiting server stealing the session
-local ASSUME_DEAD = 630 -- (Seconds) If a profile hasn't had updates for this long, quickly assume an active session belongs to a crashed server
-local START_SESSION_TIMEOUT = 120 -- (Seconds) If a session can't be started for a profile for this long, stop repeating calls to the DataStore
+local Constants: {[ConstantName]: number} = {
 
-local CRITICAL_STATE_ERROR_COUNT = 5 -- Assume critical state if this many issues happen in a short amount of time
-local CRITICAL_STATE_ERROR_EXPIRE = 120 -- (Seconds) Individual issue expiration
-local CRITICAL_STATE_EXPIRE = 120 -- (Seconds) Critical state expiration
+	AUTO_SAVE_PERIOD = 300, -- (Seconds) Time between when changes to a profile are saved to the DataStore
+	LOAD_REPEAT_PERIOD = 10, -- (Seconds) Time between successive profile reads when handling a session conflict
+	FIRST_LOAD_REPEAT = 5, -- (Seconds) Time between first and second profile read when handling a session conflict
+	SESSION_STEAL = 40, -- (Seconds) Time until a session conflict is resolved with the waiting server stealing the session
+	ASSUME_DEAD = 630, -- (Seconds) If a profile hasn't had updates for this long, quickly assume an active session belongs to a crashed server
+	START_SESSION_TIMEOUT = 120, -- (Seconds) If a session can't be started for a profile for this long, stop repeating calls to the DataStore
 
-local MAX_MESSAGE_QUEUE = 1000 -- Max messages saved in a profile that were sent using "ProfileStore:MessageAsync()"
+	CRITICAL_STATE_ERROR_COUNT = 5, -- Assume critical state if this many issues happen in a short amount of time
+	CRITICAL_STATE_ERROR_EXPIRE = 120, -- (Seconds) Individual issue expiration
+	CRITICAL_STATE_EXPIRE = 120, -- (Seconds) Critical state expiration
+
+	MAX_MESSAGE_QUEUE = 1000 -- Max messages saved in a profile that were sent using "ProfileStore:MessageAsync()"
+
+}
 
 ----- Dependencies -----
 
@@ -1204,33 +1208,27 @@ ProfileStore.__index = ProfileStore
 
 function ProfileStore.SetConstant(name, value)
 
-	if type(value) ~= "number" then
-		error(`[{script.Name}]: Invalid value type`)
+	if table.isfrozen(Constants) then
+		error("[{script.Name}]: Attempted to set constants after calling ProfileStore.New() - constants must be edited prior to initialization")
 	end
 
-	if name == "AUTO_SAVE_PERIOD" then
-		AUTO_SAVE_PERIOD = value
-	elseif name == "LOAD_REPEAT_PERIOD" then
-		LOAD_REPEAT_PERIOD = value
-	elseif name == "FIRST_LOAD_REPEAT" then
-		FIRST_LOAD_REPEAT = value
-	elseif name == "SESSION_STEAL" then
-		SESSION_STEAL = value
-	elseif name == "ASSUME_DEAD" then
-		ASSUME_DEAD = value
-	elseif name == "START_SESSION_TIMEOUT" then
-		START_SESSION_TIMEOUT = value
-	elseif name == "CRITICAL_STATE_ERROR_COUNT" then
-		CRITICAL_STATE_ERROR_COUNT = value
-	elseif name == "CRITICAL_STATE_ERROR_EXPIRE" then
-		CRITICAL_STATE_ERROR_EXPIRE = value
-	elseif name == "CRITICAL_STATE_EXPIRE" then
-		CRITICAL_STATE_EXPIRE = value
-	elseif name == "MAX_MESSAGE_QUEUE" then
-		MAX_MESSAGE_QUEUE = value
-	else
-		error(`[{script.Name}]: Invalid constant name was provided`)
+	if type(name) ~= "string" then
+		error(`[{script.Name}]: Invalid type for parameter "name" was provided - expected string, got "{typeof(name)}"`)
 	end
+
+	if Constants[name] == nil then
+		error(`[{script.Name}]: Invalid constant name "{name}" was provided`)
+	end
+
+	if type(value) ~= "number" then
+		error(`[{script.Name}]: Invalid type for parameter "value" was provided - expected number, got "{typeof(value)}"`)
+	end
+
+	if value < 0 then
+		error(`[{script.Name}]: Attempted to set value of constant "{name}" below 0 - value must not be negative`)
+	end
+
+	Constants[name] = value
 
 end
 
@@ -1249,6 +1247,8 @@ end
 function ProfileStore.New(store_name, template)
 
 	template = template or {}
+
+	Constants = table.freeze(Constants)
 
 	if type(store_name) ~= "string" then
 		error(`[{script.Name}]: Invalid or missing "store_name"`)
@@ -1441,7 +1441,7 @@ function ProfileStore:StartSessionAsync(profile_key, params)
 							if IsThisSession(active_session) == false then
 								local last_update = latest_data.MetaData.LastUpdate
 								if last_update ~= nil then
-									if os.time() - last_update > ASSUME_DEAD then
+									if os.time() - last_update > Constants.ASSUME_DEAD then
 										latest_data.MetaData.ActiveSession = {PlaceId, JobId, unique_session_id}
 										latest_data.MetaData.ForceLoadSession = nil
 										return
@@ -1563,7 +1563,7 @@ function ProfileStore:StartSessionAsync(profile_key, params)
 
 						if request_force_load == false then
 							force_load_steps = force_load_steps + 1
-							if force_load_steps >= math.ceil(SESSION_STEAL / LOAD_REPEAT_PERIOD) then
+							if force_load_steps >= math.ceil(Constants.SESSION_STEAL / Constants.LOAD_REPEAT_PERIOD) then
 								steal_session = true
 							end
 						end
@@ -1575,7 +1575,7 @@ function ProfileStore:StartSessionAsync(profile_key, params)
 						end
 						
 						-- Attempt to load the profile again after a delay
-						local wait_until = os.clock() + if request_force_load == true then FIRST_LOAD_REPEAT else LOAD_REPEAT_PERIOD
+						local wait_until = os.clock() + if request_force_load == true then Constants.FIRST_LOAD_REPEAT else Constants.LOAD_REPEAT_PERIOD
 						repeat task.wait() until os.clock() >= wait_until or ProfileStore.IsClosing == true
 
 					else
@@ -1599,7 +1599,7 @@ function ProfileStore:StartSessionAsync(profile_key, params)
 			local default_timeout = false
 
 			if params.Cancel == nil then
-				default_timeout = os.clock() - start >= START_SESSION_TIMEOUT
+				default_timeout = os.clock() - start >= Constants.START_SESSION_TIMEOUT
 			end
 			
 			if default_timeout == true or ProfileStore.IsClosing == true or cancel_condition() == true then
@@ -1669,7 +1669,7 @@ function ProfileStore:MessageAsync(profile_key, message)
 
 					-- Clearing queue if above limit:
 
-					while #update_list > MAX_MESSAGE_QUEUE do
+					while #update_list > Constants.MAX_MESSAGE_QUEUE do
 						table.remove(update_list, 1)
 					end
 
@@ -2107,12 +2107,12 @@ RunService.Heartbeat:Connect(function()
 
 	local auto_save_list_length = #AutoSaveList
 	if auto_save_list_length > 0 then
-		local auto_save_index_speed = AUTO_SAVE_PERIOD / auto_save_list_length
+		local auto_save_index_speed = Constants.AUTO_SAVE_PERIOD / auto_save_list_length
 		local os_clock = os.clock()
 		while os_clock - LastAutoSave > auto_save_index_speed do
 			LastAutoSave = LastAutoSave + auto_save_index_speed
 			local profile = AutoSaveList[AutoSaveIndex]
-			if os_clock - profile.load_timestamp < AUTO_SAVE_PERIOD / 2 then
+			if os_clock - profile.load_timestamp < Constants.AUTO_SAVE_PERIOD / 2 then
 				-- This profile is freshly loaded - auto saving immediately is not necessary:
 				profile = nil
 				for _ = 1, auto_save_list_length - 1 do
@@ -2122,7 +2122,7 @@ RunService.Heartbeat:Connect(function()
 						AutoSaveIndex = 1
 					end
 					profile = AutoSaveList[AutoSaveIndex]
-					if os_clock - profile.load_timestamp >= AUTO_SAVE_PERIOD / 2 then
+					if os_clock - profile.load_timestamp >= Constants.AUTO_SAVE_PERIOD / 2 then
 						break
 					else
 						profile = nil
@@ -2144,16 +2144,16 @@ RunService.Heartbeat:Connect(function()
 	-- Critical state handling:
 
 	if ProfileStore.IsCriticalState == false then
-		if #IssueQueue >= CRITICAL_STATE_ERROR_COUNT then
+		if #IssueQueue >= Constants.CRITICAL_STATE_ERROR_COUNT then
 			ProfileStore.IsCriticalState = true
 			ProfileStore.OnCriticalToggle:Fire(true)
 			CriticalStateStart = os.clock()
 			warn(`[{script.Name}]: Entered critical state`)
 		end
 	else
-		if #IssueQueue >= CRITICAL_STATE_ERROR_COUNT then
+		if #IssueQueue >= Constants.CRITICAL_STATE_ERROR_COUNT then
 			CriticalStateStart = os.clock()
-		elseif os.clock() - CriticalStateStart > CRITICAL_STATE_EXPIRE then
+		elseif os.clock() - CriticalStateStart > Constants.CRITICAL_STATE_EXPIRE then
 			ProfileStore.IsCriticalState = false
 			ProfileStore.OnCriticalToggle:Fire(false)
 			warn(`[{script.Name}]: Critical state ended`)
@@ -2166,7 +2166,7 @@ RunService.Heartbeat:Connect(function()
 		local issue_time = IssueQueue[1]
 		if issue_time == nil then
 			break
-		elseif os.clock() - issue_time > CRITICAL_STATE_ERROR_EXPIRE then
+		elseif os.clock() - issue_time > Constants.CRITICAL_STATE_ERROR_EXPIRE then
 			table.remove(IssueQueue, 1)
 		else
 			break

--- a/ProfileStore.luau
+++ b/ProfileStore.luau
@@ -46,6 +46,9 @@ MAD STUDIO (by loleris)
 		ProfileStore.SetConstant(name, value)
 			name    [string]
 			value   [number]
+
+		ProfileStore.SetConstants(constants)
+			constants    [table]: {name [string] = value [number]} -- Table of constants with corresponding values; e.g. {AUTO_SAVE_PERIOD = 500}
 				
 	Members [ProfileStore]:
 	
@@ -1028,7 +1031,8 @@ export type ProfileStoreModule = {
 	OnCriticalToggle: {Connect: (self: any, listener: (is_critical: boolean) -> ()) -> ({Disconnect: (self: any) -> ()})},
 	DataStoreState: "NotReady" | "NoInternet" | "NoAccess" | "Access",
 	New: <T>(store_name: string, template: (T & JSONAcceptable)?) -> (ProfileStore<T>),
-	SetConstant: (name: ConstantName, value: number) -> ()
+	SetConstant: (name: ConstantName, value: number) -> (),
+	SetConstants: ({[ConstantName]: number}) -> ()
 }
 
 local Profile = {}
@@ -1230,6 +1234,19 @@ function ProfileStore.SetConstant(name, value)
 
 	Constants[name] = value
 
+end
+
+function ProfileStore.SetConstants(constants)
+	
+	local tmp = typeof(constants)
+	if tmp ~= "table" then
+		error(`[{script.Name}]: Invalid type for parameter "constants" was provided - expected table, got "{tmp}"{tmp == "string" and ". Should you be calling .SetConstant() instead?"}`)
+	end
+
+	for k, v in constants do
+		ProfileStore.SetConstant(k, v)
+	end
+	
 end
 
 function ProfileStore.Test()

--- a/docs/api.md
+++ b/docs/api.md
@@ -281,7 +281,7 @@ If there's no data saved in the DataStore under a provided `profile_key`, `Profi
 !!! warning "`Profile.Data` will not be auto-saved when using `ProfileStore:GetAsync()`"
 
 ### :VersionQuery()
-```lua
+```luau
 ProfileStore:VersionQuery(profile_key, sort_direction?, min_date?, max_date?) --> [VersionQuery]
   -- profile_key      [string]
   -- sort_direction   nil or [Enum.SortDirection] -- Defaults to "Ascending"
@@ -345,7 +345,7 @@ end
 
 **Case example: Studying data mutation over time**
 
-```lua
+```luau
 -- You have ProfileStore working in your game. You join
 --  the game with your own account and go to https://www.unixtimestamp.com
 --  and save the current UNIX timestamp resembling present time.
@@ -647,7 +647,7 @@ be broadcasted to new functions passed to `Profile:MessageHandler()` and will co
 another time (e.g. after a player joins the game again) until `processed()` is finally called.
 
 Example:
-```lua
+```luau
 -- You can find the first half of this example in the ProfileStore:MessageAsync() section
 Profile:MessageHandler(function(message, processed)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,14 +4,14 @@
 ## Module
 
 ### .IsClosing
-``` luau
+```luau
 ProfileStore.IsClosing   [bool] (read-only)
 ```
 When the Roblox is shutting down this value will be set to `true` and
 most methods will silently fail.
 
 ### .IsCriticalState
-``` luau
+```luau
 ProfileStore.IsCriticalState   [bool] (read-only)
 ```
 After an excessive amount of DataStore calls fail this value will temporarily
@@ -19,35 +19,41 @@ be set to `true` until the DataStore starts operating normally again. Might be
 useful for analytics or notifying players in-game of possible service disturbances.
 
 ### .OnError
-``` luau
+```luau
 ProfileStore.OnError   [Signal] (message, store_name, profile_key)
 ```
-A signal for DataStore error logging. Example:
-``` luau
+A signal for DataStore error logging. 
+
+Example:
+```luau
 ProfileStore.OnError:Connect(function(error_message, store_name, profile_key)
   print(`DataStore error (Store:{store_name};Key:{profile_key}): {error_message}`)
 end)
 ```
 
 ### .OnOverwrite
-``` luau
+```luau
 ProfileStore.OnOverwrite   [Signal] (store_name, profile_key)
 ```
 A signal for events when a DataStore key returns a value that has all or some
 of it's profile components set to invalid data types. E.g., accidentally setting
-`Profile.Data` to a non table value. Example:
-``` luau
+`Profile.Data` to a non table value. 
+
+Example:
+```luau
 ProfileStore.OnOverwrite:Connect(function(store_name, profile_key)
   print(`Overwrite has occurred for Store:{store_name}, Key:{profile_key}`)
 end)
 ```
 
 ### .OnCriticalToggle
-``` luau
+```luau
 ProfileStore.OnCriticalToggle   [Signal] (is_critical)
 ```
-A signal that is called whenever `ProfileStore.IsCriticalState` changes. Example:
-``` luau
+A signal that is called whenever `ProfileStore.IsCriticalState` changes. 
+
+Example:
+```luau
 ProfileStore.OnCriticalToggle:Connect(function(is_critical)
   if is_critical == true then
     print(`ProfileStore entered critical state`)
@@ -58,7 +64,7 @@ end)
 ```
 
 ### .DataStoreState
-``` luau
+```luau
 ProfileStore.DataStoreState   [string] "NotReady" | "NoInternet" | "NoAccess" | "Access"
 ```
 Indicates ProfileStore's access to the DataStore. If at first check `ProfileStore.DataStoreState`
@@ -66,7 +72,7 @@ is `"NotReady"`, it will eventually change to one of the other 3 possible values
 never change again. `"Access"` means ProfileStore can write to the DataStore.
 
 ### .New()
-``` luau
+```luau
 ProfileStore.New(store_name, template?) --> [ProfileStore]
   -- store_name   [string] -- DataStore name
   -- template     nil or [table] -- Profile.Data will default
@@ -80,20 +86,33 @@ in Roblox [DataStoreService](https://create.roblox.com/docs/reference/engine/cla
     Using templates and reconciliation is completely optional and you may alter `Profile.Data` with your own code alone.
 
 ### .SetConstant()
-``` luau
+```luau
 ProfileStore.SetConstant(name, value)
   -- name    [string] "AUTO_SAVE_PERIOD" | "LOAD_REPEAT_PERIOD" | "FIRST_LOAD_REPEAT" | "SESSION_STEAL"
-|   -- "ASSUME_DEAD" | "START_SESSION_TIMEOUT" | "CRITICAL_STATE_ERROR_COUNT" | "CRITICAL_STATE_ERROR_EXPIRE"
-|   -- "CRITICAL_STATE_EXPIRE" | "MAX_MESSAGE_QUEUE"
+  -- | "ASSUME_DEAD" | "START_SESSION_TIMEOUT" | "CRITICAL_STATE_ERROR_COUNT" | "CRITICAL_STATE_ERROR_EXPIRE"
+  -- | "CRITICAL_STATE_EXPIRE" | "MAX_MESSAGE_QUEUE"
   -- value   [number]
 ```
 A feature for experienced developers who understand how ProfileStore works for changing internal constants
 without having to fork the ProfileStore project.
 
+!!! warning 
+    Changing these variables could result in unintended game-breaking functionality. 
+    Unless you're familiar with the Roblox [DataStoreService API Limits](https://create.roblox.com/docs/cloud-services/data-stores/error-codes-and-limits#server-limits) and know what you're doing, you shouldn't change these.
+
+Example:
+```luau
+-- This will change the seconds between auto-saves to 300 (the default)
+ProfileStore.SetConstant("AUTO_SAVE_PERIOD", 300)
+
+-- This will change the maximum number of unprocessed messages saved to a Profile to 1000 (the default)
+ProfileStore.SetConstant("MAX_MESSAGE_QUEUE", 1000)
+```
+
 ## ProfileStore
 
 ### .Mock
-```lua
+```luau
 local PlayerStore = ProfileStore.New("PlayerData", {})
 
 -- This profile would be saved to the DataStore:
@@ -116,7 +135,7 @@ using the same key from `ProfileStore` and `ProfileStore.Mock` will be different
 `ProfileStore.Mock` is useful for customizing your testing environment in cases where you want
 to [enable Roblox API services](https://create.roblox.com/docs/cloud-services/data-stores#enabling-studio-access) in studio,
 but don't want ProfileStore to save to live keys:
-``` luau
+```luau
 local RunService = game:GetService("RunService")
 local PlayerStore = ProfileStore.New("PlayerData", {})
 if RunService:IsStudio() == true then
@@ -128,13 +147,13 @@ end
     Even when Roblox API services are unavailable, `ProfileStore` and `ProfileStore.Mock` will store profiles separately from each other.
 
 ### .Name
-``` luau
+```luau
 ProfileStore.Name   [string] (read-only)
 ```
 The name of the DataStore that was defined as the first argument of `ProfileStore.New()`.
 
 ### :StartSessionAsync()
-``` luau
+```luau
 ProfileStore:StartSessionAsync(profile_key, params?) --> [Profile] or nil
   -- profile_key   [string] -- DataStore key
   -- params        nil or [table]: {
@@ -165,7 +184,7 @@ This argument is only useful for debugging.
 !!! failure "The `Steal` argument bypasses session locks which are needed for item "dupe" prevention - use this only if you know what you are doing"
 
 Example usage:
-``` luau
+```luau
 local Players = game:GetService("Players")
 local profile = PlayerStore:StartSessionAsync(tostring(player.UserId), {
   Cancel = function()
@@ -183,10 +202,10 @@ local profile = PlayerStore:StartSessionAsync(tostring(player.UserId), {
     the player if `:StartSessionAsync()` does not return a `Profile` object.
 
 ### :MessageAsync()
-``` luau
+```luau
 ProfileStore:MessageAsync(profile_key, message) --> is_success [bool]
   -- profile_key   [string] -- DataStore key
-  -- message       [table] -- Data to be stored in the profile before it's received
+  -- message       [table] -- Data to be stored in the profile before it's received and handled
 ```
 Sends a message to a profile regardless of whether a server has started a session for it.
 Each `ProfileStore:MessageAsync()` call will use one [:UpdateAsync()](https://create.roblox.com/docs/reference/engine/classes/GlobalDataStore#UpdateAsync)
@@ -197,8 +216,37 @@ paid items to in-game friends that may or may not be online at the moment**. If 
 of your messages failing to deliver, use [MessagingService](https://create.roblox.com/docs/reference/engine/classes/MessagingService) instead.
 See [`Profile:MessageHandler()`](#messagehandler) to learn how to receive messages.
 
+Example:
+```luau
+-- You can find the second half of this example in the Profile:MessageHandler() section
+local Success = ProfileStore:MessageAsync(profile_key, {
+  
+  -- Updating a players data using a message:
+  Data = {
+    Coins = 5,
+    Gems = -5,
+    DogName = "John Doe"
+  }
+
+  -- You're not limited to just updating a players data!
+  -- You could also, for example, ban a player that's offline (on their next join) or in a different server using a message:
+  Ban = {
+    DisplayReason = "Exploiting",
+    PrivateReason = "Banned by ModeratorNameHere",
+    Duration = 7*60*60*24
+  }
+
+})
+
+if Success then
+  print("Message sent successfully!")
+else
+  warn("Message could not be sent!")
+end
+```
+
 ### :GetAsync()
-``` luau
+```luau
 ProfileStore:GetAsync(profile_key, version?) --> [Profile] or nil
   -- profile_key   [string]
   -- version       nil or [string] -- DataStore key version
@@ -233,7 +281,7 @@ Date definitions are easier with the [DateTime (Official documentation)](https:/
 
 **Case example: "I lost all of my coins on August 14th!"**
 
-```lua
+```luau
 -- Get a ProfileStore object with the same arguments you passed to the
 --  ProfileStore that loads player Profiles:
 
@@ -339,7 +387,7 @@ end
 ```
 
 ### :RemoveAsync()
-``` luau
+```luau
 ProfileStore:RemoveAsync(profile_key) --> is_success [bool]
   -- profile_key   [string] -- DataStore key
 ```
@@ -349,7 +397,7 @@ profiles created through `ProfileStore.Mock` after `Profile:EndSession()` and it
 ## Profile
 
 ### .Data
-``` luau
+```luau
 Profile.Data   [table]
 ```
 This is the data that would resemble player progress or other data you wish to save to the [DataStore](https://create.roblox.com/docs/cloud-services/data-stores).
@@ -360,26 +408,26 @@ to a new table reference (e.g. `Profile.Data = {}`). When `Profile:IsActive()` r
 stored to the DataStore.
 
 ### .LastSavedData
-``` luau
+```luau
 Profile.LastSavedData   [table] (read-only)
 ```
 This is a version of `Profile.Data` that has been successfully stored to the DataStore. Useful for
 verifying what particular data has been saved, or for securely handling developer product purchases.
 
 ### .FirstSessionTime
-``` luau
+```luau
 Profile.FirstSessionTime   [number] (read-only) -- Unix time
 ```
 A [Unix timestamp]((https://en.wikipedia.org/wiki/Unix_time)) of when the profile was created.
 
 ### .SessionLoadCount
-``` luau
+```luau
 Profile.SessionLoadCount   [number] (read-only)
 ```
 Amount of times a session has been started for this profile.
 
 ### .Session
-``` luau
+```luau
 Profile.Session   [table?] (read-only) -- nil or {PlaceId = number, JobId = string}
 ```
 This value never changes after a profile object is created. After you start a session for a profile,
@@ -389,7 +437,7 @@ may be equal to `nil` or a `table` with it's `PlaceId` and `JobId` members set t
 has a session started for the profile.
 
 ### .RobloxMetaData
-``` luau
+```luau
 Profile.RobloxMetaData   [table]
 ```
 !!! failure "Be cautious of very harsh limits for maximum Roblox Metadata size - As of writing this, total table content size cannot exceed 300 characters."
@@ -400,20 +448,20 @@ except changes will truly get saved on the next auto-save cycle or when the prof
 on Roblox metadata limits [can be found here](https://create.roblox.com/docs/cloud-services/data-stores/error-codes-and-limits#metadata-limits).
 
 ### .UserIds
-``` luau
+```luau
 Profile.UserIds [table] (read-only) -- {user_id [number], ...}
 ```
 User ids associated with this profile. Entries must be added with [Profile:AddUserId()](#adduserid) and removed with [Profile:RemoveUserId()](#removeuserid).
 
 ### .KeyInfo
-``` luau
+```luau
 Profile.KeyInfo [DataStoreKeyInfo]
 ```
 The [DataStoreKeyInfo (Official documentation)](https://create.roblox.com/docs/reference/engine/classes/DataStoreKeyInfo)
 instance related to this profile.
 
 ### .OnSave
-``` luau
+```luau
 Profile.OnSave:Connect(function()
   print(`Profile.Data is about to be saved to the DataStore`)
 end)
@@ -425,7 +473,7 @@ are expected to save when done at the moment of `Profile.OnSave` firing, but thi
 after a session has been ended.
 
 ### .OnLastSave
-``` luau
+```luau
 Profile.OnLastSave:Connect(function(reason: "Manual" | "External" | "Shutdown")
   print(`Profile.Data is about to be saved to the DataStore for the last time; Reason: {reason}`)
 end)
@@ -439,8 +487,10 @@ are expected to save when done at the moment of `Profile.OnLastSave` firing, but
 - **`"Shutdown"`** - The profile session has been ended automatically due to the server shutting down
 
 One of `Profile.OnLastSave` uses is giving "logout penalties" where a player may receive punishment for
-closing the game at the wrong time. Example:
-``` luau
+leaving the game at the wrong time. 
+
+Example:
+```luau
 local InCombat = false
 
 Profile.OnLastSave:Connect(function(reason)
@@ -464,7 +514,7 @@ end)
     You should design your data saving code in a way where reacting to `Profile.OnLastSave` is not critical.
 
 ### .OnSessionEnd
-``` luau
+```luau
 Profile.OnSessionEnd:Connect(function()
   print(`Profile session has ended - Profile.Data will no longer be saved to the DataStore`)
 end)
@@ -475,7 +525,7 @@ After the `Profile.OnSessionEnd` signal is fired, no further changes to `Profile
 `Profile.OnSessionEnd` will fire even when a profile session is stolen, whereas `Profile.OnLastSave` would not.
 In some cases it would be preferable to kick the player from the game when this signal is fired:
 
-``` luau
+```luau
 Profile.OnSessionEnd:Connect(function()
   player:Kick(`Your data has been loaded on another server - please rejoin`)
 end)
@@ -486,7 +536,7 @@ end)
     Use `Profile.OnLastSave` instead.
 
 ### .OnAfterSave
-``` luau
+```luau
 Profile.OnAfterSave:Connect(function(last_saved_data)
   print(`Profile.Data has been successfully saved to the DataStore:`, last_saved_data)
 end)
@@ -497,20 +547,20 @@ After this signal is fired, the values [`Profile.LastSavedData`](#lastsaveddata)
 successfully saved to the DataStore.
 
 ### .ProfileStore
-``` luau
+```luau
 Profile.ProfileStore   [ProfileStore] -- ProfileStore object this profile belongs to
 ```
 The [`ProfileStore`](#new) object that was used to create this profile.
 
 ### .Key
-``` luau
+```luau
 Profile.Key   [string] -- DataStore key
 ```
 The DataStore key of this profile. This is the first passed argument to [`ProfileStore:StartSessionAsync()`](#startsessionasync)
 or [`ProfileStore:GetAsync()`](#getasync).
 
 ### :IsActive()
-``` luau
+```luau
 Profile:IsActive() --> [bool]
 ```
 If  `Profile:IsActive()` returns `true`, changes to `Profile.Data` will be saved - this guarantee
@@ -518,7 +568,7 @@ will no longer be valid after yielding (e.g. using `task.wait()` or `:WaitForChi
 you may make changes to two profiles immediately without yielding after `Profile:IsActive()` returns `true` for the two profiles.
 
 ### :Reconcile()
-``` luau
+```luau
 Profile:Reconcile()
 ```
 Fills in missing variables inside `Profile.Data` from a template table that was provided as a second argument
@@ -526,15 +576,15 @@ to [`ProfileStore.New()`](#new). `Profile:Reconcile()` can be useful if you're m
 data template over the course of your game's development.
 
 ### :EndSession()
-``` luau
+```luau
 Profile:EndSession()
 ```
 Stops auto-saving for this profile and saves `Profile.Data` to the DataStore for
 the last time. Call this method after you're done working with the `Profile` object created by [`ProfileStore:StartSessionAsync()`](#startsessionasync).
 
 Example:
-``` luau
-Players.PlayerRemoving:Connect(function(player)
+```luau
+game.Players.PlayerRemoving:Connect(function(player)
     
   local profile = Profiles[player]
 	
@@ -547,22 +597,22 @@ end)
 ```
 
 ### :AddUserId()
-``` luau
+```luau
 Profile:AddUserId(user_id)
--- user_id [number]
+  -- user_id [number]
 ```
 Associates a `UserId` with the profile. Multiple users can be associated with a single profile by calling this method for each individual `UserId`.
 The primary use of this method is to comply with GDPR (The right to erasure). More information in [official documentation](https://create.roblox.com/docs/cloud-services/data-stores#metadata).
 
 ### :RemoveUserId()
-``` luau
+```luau
 Profile:RemoveUserId(user_id)
--- user_id [number]
+  -- user_id [number]
 ```
 Unassociates a `UserId` with the profile.
 
 ### :MessageHandler()
-``` luau
+```luau
 Profile:MessageHandler(function(message, processed)
   print(`Message received:`, message)
   processed()
@@ -576,8 +626,49 @@ other functions passed to `Profile:MessageHandler()` and will broadcast the same
 be broadcasted to new functions passed to `Profile:MessageHandler()` and will continue to do so when a profile session is started
 another time (e.g. after a player joins the game again) until `processed()` is finally called.
 
+Example:
+```lua
+-- You can find the first half of this example in the ProfileStore:MessageAsync() section
+Profile:MessageHandler(function(message, processed)
+
+  -- Handling a message that updates a players data:
+  if message.Data then
+    for key, value in message.Data do
+      if type(value) == "number" then
+        Profile.Data[key] += value
+      elseif type(value) == "string" then
+        Profile.Data[key] = value
+      end
+    end
+  end
+
+  -- Handling a message that bans a player:
+  if message.Ban then
+    local Success, Result = pcall(function()
+      game.Players:BanAsync({
+        UserIds = {player.UserId},
+        DisplayReason = message.Ban.DisplayReason,
+        PrivateReason = message.Ban.PrivateReason,
+        Duration = message.Ban.Duration
+      })
+    end)
+
+    if Success then
+      print("Successfully banned player using a message!")
+    else
+      warn("Could not ban player! Reason:", tostring(result))
+    end
+  end
+
+  -- Once the message has been handled and you've done everything you've needed to, call
+  -- processed() to ensure it doesn't get handled again
+  processed()
+
+end)
+```
+
 ### :Save()
-``` luau
+```luau
 Profile:Save()
 ```
 Calling `Profile:Save()` will immediately save `Profile.Data` to the DataStore when a profile session is still active (`Profile:IsActive()` returns `true`).
@@ -588,7 +679,7 @@ call - see the official documentation on [DataStore limits](https://create.roblo
 evaluate your use case.
 
 ### :SetAsync()
-``` luau
+```luau
 Profile:SetAsync()
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -112,6 +112,23 @@ ProfileStore.SetConstant("AUTO_SAVE_PERIOD", 300)
 ProfileStore.SetConstant("MAX_MESSAGE_QUEUE", 1000)
 ```
 
+### .SetConstants()
+```luau
+ProfileStore.SetConstants(constants)
+  -- constants  [table]: {name [string] = value [number]}
+```
+This fulfills the same purpose as `ProfileStore.SetConstant()`, but instead takes a table of multiple constants
+and corresponding values to set them to all in one method call rather than needing to use multiple. This does
+not have a performance advantage and is just preferential.
+
+Example:
+```luau
+ProfileStore.SetConstants({
+  AUTO_SAVE_PERIOD = 300,
+  MAX_MESSAGE_QUEUE = 1000
+})
+```
+
 ## ProfileStore
 
 ### .Mock

--- a/docs/api.md
+++ b/docs/api.md
@@ -100,6 +100,9 @@ without having to fork the ProfileStore project.
     Changing these variables could result in unintended game-breaking functionality. 
     Unless you're familiar with the Roblox [DataStoreService API Limits](https://create.roblox.com/docs/cloud-services/data-stores/error-codes-and-limits#server-limits) and know what you're doing, you shouldn't change these.
 
+!!! notice
+    Constants cannot be edited after calling `ProfileStore.New()`. Doing so will result in an error.
+
 Example:
 ```luau
 -- This will change the seconds between auto-saves to 300 (the default)

--- a/selene.toml
+++ b/selene.toml
@@ -1,0 +1,1 @@
+std = "roblox"


### PR DESCRIPTION
I'm aware I probably should've just made multiple pulls. Sorry about that.

- Adds selene.toml for Luau linting in VSCode.
- Moves the constants to a dictionary, which is then frozen when calling `ProfileStore.New()`.
- Adds `ProfileStore.SetConstants()`, which takes a dictionary (`{[ConstantName]: number}`). Purely preferential.
- Improves api.md consistency, fixes some blocks being lua instead of luau thereby not linting correctly on the website, adds `.SetConstant()` warning and example, and adds `:MessageAsync()` and `:MessageHandler()` examples.
- Adds LogInfo(), LogWarn(), and LogError() local functions to fix the lowercase print prefix ("[profilestore]:") when using Wally.
- Expands upon information logged within warns and errors.

I would propose removing the `.SetConstant()` function altogether and instead having differing constants (if any) passed into the `.New()` constructor as is common among modules such as [discord.js with client intents](https://discordjs.guide/popular-topics/intents.html#enabling-intents). This seems like it would require some restructuring though, so I wouldn't blame you for not wanting to.