### PR TITLE
Sanitize the utf8 characters from the keys/values of the profile.

### DIFF
--- a/ProfileStore.luau
+++ b/ProfileStore.luau
@@ -504,6 +504,118 @@ local function MockUpdateAsync(mock_data_store, profile_store_name, key, transfo
 
 end
 
+local function clean_utf8_string(str)
+	local result = {}
+	local i = 1
+
+	while i <= #str do
+		local c = string.byte(str, i)
+
+		if c >= 0x00 and c <= 0x7F then
+			table.insert(result, string.char(c))
+			i = i + 1
+		elseif c >= 0xC2 and c <= 0xDF then
+			local b2 = string.byte(str, i + 1)
+			if b2 and b2 >= 0x80 and b2 <= 0xBF then
+				table.insert(result, str:sub(i, i + 1))
+				i = i + 2
+			else
+				i = i + 1
+			end
+		elseif c == 0xE0 then
+			local b2 = string.byte(str, i + 1)
+			local b3 = string.byte(str, i + 2)
+			if b2 and b3 and b2 >= 0xA0 and b2 <= 0xBF and b3 >= 0x80 and b3 <= 0xBF then
+				table.insert(result, str:sub(i, i + 2))
+				i = i + 3
+			else
+				i = i + 1
+			end
+		elseif c >= 0xE1 and c <= 0xEC or c >= 0xEE and c <= 0xEF then
+			local b2 = string.byte(str, i + 1)
+			local b3 = string.byte(str, i + 2)
+			if b2 and b3 and b2 >= 0x80 and b2 <= 0xBF and b3 >= 0x80 and b3 <= 0xBF then
+				table.insert(result, str:sub(i, i + 2))
+				i = i + 3
+			else
+				i = i + 1
+			end
+		elseif c == 0xED then
+			local b2 = string.byte(str, i + 1)
+			local b3 = string.byte(str, i + 2)
+			if b2 and b3 and b2 >= 0x80 and b2 <= 0x9F and b3 >= 0x80 and b3 <= 0xBF then
+				table.insert(result, str:sub(i, i + 2))
+				i = i + 3
+			else
+				i = i + 1
+			end
+		elseif c == 0xF0 then
+			local b2 = string.byte(str, i + 1)
+			local b3 = string.byte(str, i + 2)
+			local b4 = string.byte(str, i + 3)
+			if b2 and b3 and b4 and b2 >= 0x90 and b2 <= 0xBF and b3 >= 0x80 and b3 <= 0xBF and b4 >= 0x80 and b4 <= 0xBF then
+				table.insert(result, str:sub(i, i + 3))
+				i = i + 4
+			else
+				i = i + 1
+			end
+		elseif c >= 0xF1 and c <= 0xF3 then
+			local b2 = string.byte(str, i + 1)
+			local b3 = string.byte(str, i + 2)
+			local b4 = string.byte(str, i + 3)
+			if b2 and b3 and b4 and b2 >= 0x80 and b2 <= 0xBF and b3 >= 0x80 and b3 <= 0xBF and b4 >= 0x80 and b4 <= 0xBF then
+				table.insert(result, str:sub(i, i + 3))
+				i = i + 4
+			else
+				i = i + 1
+			end
+		elseif c == 0xF4 then
+			local b2 = string.byte(str, i + 1)
+			local b3 = string.byte(str, i + 2)
+			local b4 = string.byte(str, i + 3)
+			if b2 and b3 and b4 and b2 >= 0x80 and b2 <= 0x8F and b3 >= 0x80 and b3 <= 0xBF and b4 >= 0x80 and b4 <= 0xBF then
+				table.insert(result, str:sub(i, i + 3))
+				i = i + 4
+			else
+				i = i + 1
+			end
+		else
+			i = i + 1
+		end
+	end
+
+	return table.concat(result)
+end
+
+local function clean_table(t)
+
+	--/Check if the table is valid
+	if type(t) ~= "table" then return end
+
+	--/Iterate through the table
+	for key, value in pairs(t) do
+		
+		--/Clean the key if it's a string
+		local cleaned_key = (type(key) == "string") and clean_utf8_string(key) or key
+
+		--/Recursively clean the table
+		if type(value) == "table" then
+			clean_table(value)
+		elseif type(value) == "string" then
+			value = clean_utf8_string(value)
+		end
+
+		--/Check if the key is different from the original key
+		if key ~= cleaned_key then
+			t[key] = nil
+		end
+
+		--/Set the cleaned key
+		t[cleaned_key] = value
+
+	end
+end
+
 local function UpdateAsync(profile_store, profile_key, transform_params, is_user_mock, is_get_call, version) --> loaded_data, key_info
 	--transform_params = {
 	--	ExistingProfileHandle = function(latest_data),
@@ -584,6 +696,9 @@ local function UpdateAsync(profile_store, profile_key, transform_params, is_user
 			if overwritten == true then
 				latest_data.WasOverwritten = true -- Temporary tag that will be removed on first save
 			end
+
+			--/Make sure the data is clean from utf8 characters
+			clean_table(latest_data)
 
 			return latest_data, latest_data.UserIds, latest_data.RobloxMetaData
 		end

--- a/ProfileStoreTest.server.luau
+++ b/ProfileStoreTest.server.luau
@@ -733,6 +733,90 @@ task.spawn(function()
 		TestPass(`Test #6`, is_pass)
 		
 	end
+
+	-- Test #7: (utf8 character test)
+	
+	do
+		
+		local bad_keys = {
+			"Hello World",
+			"\237\190\140",
+			"\xED\xA0\x80\xED\xB0\x80",
+			"Hello World\255",
+			"\237\190\140Hello World\237\190\140",
+			"\xED\xA0\x80\xED\xB0\x80Hello World\xED\xA0\x80\xED\xB0\x80",
+			-- Borrowed word sample
+			"ï",
+			"Hello Worldï",
+			-- Hiragana sample
+			"女",
+			"Hello World女",
+			-- Chinese sample
+			"我",
+			"Hello World我",
+			-- Surrogate
+			"\237\190\140Hello Worldï",
+			"\237\190\140Hello World女",
+			"\237\190\140Hello World我",
+			-- Surrogate
+			"\xED\xA0\x80\xED\xB0\x80Hello Worldï",
+			"\xED\xA0\x80\xED\xB0\x80Hello World女",
+			"\xED\xA0\x80\xED\xB0\x80Hello World我",
+			-- Emojis
+			"😀 😃 😄 😁 😆 😅 😂 🤣 🥲 🥹 ☺️ 😊 😇 🙂 🙃 😉 😌 😍 🥰 😘 😗 😙 😚 😋 😛 😝 😜 🤪 🤨 🧐 🤓 😎 🥸 🤩 🥳 😏 😒 😞 😔 😟 😕 🙁 ☹️ 😣 😖 😫 😩 🥺 😢 😭 😮‍💨 😤 😠 😡 🤬 🤯 😳 🥵 🥶 😱 😨 😰 😥 😓 🫣 🤗 🫡 🤔 🫢 🤭 🤫 🤥 😶 😶‍🌫️ 😐 😑 😬 🫨 🫠 🙄 😯 😦 😧 😮 😲 🥱 😴 🤤 😪 😵 😵‍💫 🫥 🤐 🥴 🤢 🤮 🤧 😷 🤒 🤕 🤑 🤠 😈 👿 👹 👺 🤡 💩 👻 💀 ☠️ 👽 👾 🤖 🎃 😺 😸 😹 😻 😼 😽 🙀 😿 😾 ",
+			-- Hiragana
+			[[あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん]],
+			-- Katakana
+			[[アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン]],
+			-- Russian
+			[[АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯбвгдеёжзийклмнопрстуфхцчшщъыьэюя]],
+			-- Arabic 
+			-- abjadī
+			[[أبجدهوزحطيكلمنسعفصقرشتثخذضظغ]],
+			-- hijāʾī
+			[[ابتثجحخدذرزسشصضطظعغفقكلمنهوي]],
+			-- Greek
+			[[ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩαβγδεζηθικλμνξοπρστυφχψω]],
+			-- Egyptian hieroglyphics
+			[[𓀀 𓀁 𓀂 𓀃 𓀄 𓀅 𓀆 𓀇 𓀈 𓀉 𓀊 𓀋 𓀌 𓀍 𓀎 𓀏 𓀐 𓀑 𓀒 𓀓 𓀔 𓀕 𓀖 𓀗 𓀘 𓀙 𓀚 𓀛 𓀜 𓀝 𓀞 𓀟 𓀠 𓀡 𓀢 𓀣 𓀤 𓀥 𓀦 𓀧 𓀨 𓀩 𓀪 𓀫 𓀬 𓀭 𓀮 𓀯 𓀰 𓀱 𓀲 𓀳 𓀴 𓀵 𓀶 𓀷 𓀸 𓀹 𓀺 𓀻 𓀼 𓀽 𓀾 𓀿 𓁀 𓁁 𓁂 𓁃 𓁄 𓁅 𓁆 𓁇 𓁈 𓁉 𓁊 𓁋 𓁌 𓁍 𓁎 𓁏 𓁐 𓁑 𓁒 𓁓 𓁔 𓁕 𓁖 𓁗 𓁘 𓁙 𓁚 𓁛 𓁜 𓁝 𓁞 𓁟 𓁠 𓁡 𓁢 𓁣 𓁤 𓁥 𓁦 𓁧 𓁨 𓁩 𓁪 𓁫 𓁬 𓁭 𓁮 𓁯 𓁰 𓁱 𓁲 𓁳 𓁴 𓁵 𓁶 𓁷 𓁸 𓁹 𓁺 𓁻 𓁼 𓁽 𓁾 𓁿 𓂀 𓂁 𓂂 𓂃 𓂄 𓂅 𓂆 𓂇 𓂈 𓂉 𓂊 𓂋 𓂌 𓂍 𓂎 𓂏 𓂐 𓂑 𓂒 𓂓 𓂔 𓂕 𓂖 𓂗 𓂘 𓂙 𓂚 𓂛 𓂜 𓂝 𓂞 𓂟 𓂠 𓂡 𓂢 𓂣 𓂤 𓂥 𓂦 𓂧 𓂨 𓂩 𓂪 𓂫 𓂬 𓂭 𓂮 𓂯 𓂰 𓂱 𓂲 𓂳 𓂴 𓂵 𓂶 𓂷 𓂸 𓂹 𓂺 𓂻 𓂼 𓂽 𓂾 𓂿 𓃀 𓃁 𓃂 𓃃 𓃄 𓃅 𓃆 𓃇 𓃈 𓃉 𓃊 𓃋 𓃌 𓃍 𓃎 𓃏 𓃐 𓃑 𓃒 𓃓 𓃔 𓃕 𓃖 𓃗 𓃘 𓃙 𓃚 𓃛 𓃜 𓃝 𓃞 𓃟 𓃠 𓃡 𓃢 𓃣 𓃤 𓃥 𓃦 𓃧 𓃨 𓃩 𓃪 𓃫 𓃬 𓃭 𓃮 𓃯 𓃰 𓃱 𓃲 𓃳 𓃴 𓃵 𓃶 𓃷 𓃸 𓃹 𓃺 𓃻 𓃼 𓃽 𓃾 𓃿 𓄀 𓄁 𓄂 𓄃 𓄄 𓄅 𓄆 𓄇 𓄈 𓄉 𓄊 𓄋 𓄌 𓄍 𓄎 𓄏 𓄐 𓄑 𓄒 𓄓 𓄔 𓄕 𓄖 𓄗 𓄘 𓄙 𓄚 𓄛 𓄜 𓄝 𓄞 𓄟 𓄠 𓄡 𓄢 𓄣 𓄤 𓄥 𓄦 𓄧 𓄨 𓄩 𓄪 𓄫 𓄬 𓄭 𓄮 𓄯 𓄰 𓄱 𓄲 𓄳 𓄴 𓄵 𓄶 𓄷 𓄸 𓄹 𓄺 𓄻 𓄼 𓄽 𓄾 𓄿 𓅀 𓅁 𓅂 𓅃 𓅄 𓅅 𓅆 𓅇 𓅈 𓅉 𓅊 𓅋 𓅌 𓅍 𓅎 𓅏 𓅐 𓅑 𓅒 𓅓 𓅔 𓅕 𓅖 𓅗 𓅘 𓅙 𓅚 𓅛 𓅜 𓅝 𓅞 𓅟 𓅠 𓅡 𓅢 𓅣 𓅤 𓅥 𓅦 𓅧 𓅨 𓅩 𓅪 𓅫 𓅬 𓅭 𓅮 𓅯 𓅰 𓅱 𓅲 𓅳 𓅴 𓅵 𓅶 𓅷 𓅸 𓅹 𓅺 𓅻 𓅼 𓅽 𓅾 𓅿 𓆀 𓆁 𓆂 𓆃 𓆄 𓆅 𓆆 𓆇 𓆈 𓆉 𓆊 𓆋 𓆌 𓆍 𓆎 𓆏 𓆐 𓆑 𓆒 𓆓 𓆔 𓆕 𓆖 𓆗 𓆘 𓆙 𓆚 𓆛 𓆜 𓆝 𓆞 𓆟 𓆠 𓆡 𓆢 𓆣 𓆤 𓆥 𓆦 𓆧 𓆨 𓆩 𓆪 𓆫 𓆬 𓆭 𓆮 𓆯 𓆰 𓆱 𓆲 𓆳 𓆴 𓆵 𓆶 𓆷 𓆸 𓆹 𓆺 𓆻 𓆼 𓆽 𓆾 𓆿 𓇀 𓇁 𓇂 𓇃 𓇄 𓇅 𓇆 𓇇 𓇈 𓇉 𓇊 𓇋 𓇌 𓇍 𓇎 𓇏 𓇐 𓇑 𓇒 𓇓 𓇔 𓇕 𓇖 𓇗 𓇘 𓇙 𓇚 𓇛 𓇜 𓇝 𓇞 𓇟 𓇠 𓇡 𓇢 𓇣 𓇤 𓇥 𓇦 𓇧 𓇨 𓇩 𓇪 𓇫 𓇬 𓇭 𓇮 𓇯 𓇰 𓇱 𓇲 𓇳 𓇴 𓇵 𓇶 𓇷 𓇸 𓇹 𓇺 𓇻 𓇼 𓇽 𓇾 𓇿 𓈀 𓈁 𓈂 𓈃 𓈄 𓈅 𓈆 𓈇 𓈈 𓈉 𓈊 𓈋 𓈌 𓈍 𓈎 𓈏 𓈐 𓈑 𓈒 𓈓 𓈔 𓈕 𓈖 𓈗 𓈘 𓈙 𓈚 𓈛 𓈜 𓈝 𓈞 𓈟 𓈠 𓈡 𓈢 𓈣 𓈤 𓈥 𓈦 𓈧 𓈨 𓈩 𓈪 𓈫 𓈬 𓈭 𓈮 𓈯 𓈰 𓈱 𓈲 𓈳 𓈴 𓈵 𓈶 𓈷 𓈸 𓈹 𓈺 𓈻 𓈼 𓈽 𓈾 𓈿 𓉀 𓉁 𓉂 𓉃 𓉄 𓉅 𓉆 𓉇 𓉈 𓉉 𓉊 𓉋 𓉌 𓉍 𓉎 𓉏 𓉐 𓉑 𓉒 𓉓 𓉔 𓉕 𓉖 𓉗 𓉘 𓉙 𓉚 𓉛 𓉜 𓉝 𓉞 𓉟 𓉠 𓉡 𓉢 𓉣 𓉤 𓉥 𓉦 𓉧 𓉨 𓉩 𓉪 𓉫 𓉬 𓉭 𓉮 𓉯 𓉰 𓉱 𓉲 𓉳 𓉴 𓉵 𓉶 𓉷 𓉸 𓉹 𓉺 𓉻 𓉼 𓉽 𓉾 𓉿 𓊀 𓊁 𓊂 𓊃 𓊄 𓊅 𓊆 𓊇 𓊈 𓊉 𓊊 𓊋 𓊌 𓊍 𓊎 𓊏 𓊐 𓊑 𓊒 𓊓 𓊔 𓊕 𓊖 𓊗 𓊘 𓊙 𓊚 𓊛 𓊜 𓊝 𓊞 𓊟 𓊠 𓊡 𓊢 𓊣 𓊤 𓊥 𓊦 𓊧 𓊨 𓊩 𓊪 𓊫 𓊬 𓊭 𓊮 𓊯 𓊰 𓊱 𓊲 𓊳 𓊴 𓊵 𓊶 𓊷 𓊸 𓊹 𓊺 𓊻 𓊼 𓊽 𓊾 𓊿 𓋀 𓋁 𓋂 𓋃 𓋄 𓋅 𓋆 𓋇 𓋈 𓋉 𓋊 𓋋 𓋌 𓋍 𓋎 𓋏 𓋐 𓋑 𓋒 𓋓 𓋔 𓋕 𓋖 𓋗 𓋘 𓋙 𓋚 𓋛 𓋜 𓋝 𓋞 𓋟 𓋠 𓋡 𓋢 𓋣 𓋤 𓋥 𓋦 𓋧 𓋨 𓋩 𓋪 𓋫 𓋬 𓋭 𓋮 𓋯 𓋰 𓋱 𓋲 𓋳 𓋴 𓋵 𓋶 𓋷 𓋸 𓋹 𓋺 𓋻 𓋼 𓋽 𓋾 𓋿 𓌀 𓌁 𓌂 𓌃 𓌄 𓌅 𓌆 𓌇 𓌈 𓌉 𓌊 𓌋 𓌌 𓌍 𓌎 𓌏 𓌐 𓌑 𓌒 𓌓 𓌔 𓌕 𓌖 𓌗 𓌘 𓌙 𓌚 𓌛 𓌜 𓌝 𓌞 𓌟 𓌠 𓌡 𓌢 𓌣 𓌤 𓌥 𓌦 𓌧 𓌨 𓌩 𓌪 𓌫 𓌬 𓌭 𓌮 𓌯 𓌰 𓌱 𓌲 𓌳 𓌴 𓌵 𓌶 𓌷 𓌸 𓌹 𓌺 𓌻 𓌼 𓌽 𓌾 𓌿 𓍀 𓍁 𓍂 𓍃 𓍄 𓍅 𓍆 𓍇 𓍈 𓍉 𓍊 𓍋 𓍌 𓍍 𓍎 𓍏 𓍐 𓍑 𓍒 𓍓 𓍔 𓍕 𓍖 𓍗 𓍘 𓍙 𓍚 𓍛 𓍜 𓍝 𓍞 𓍟 𓍠 𓍡 𓍢 𓍣 𓍤 𓍥 𓍦 𓍧 𓍨 𓍩 𓍪 𓍫 𓍬 𓍭 𓍮 𓍯 𓍰 𓍱 𓍲 𓍳 𓍴 𓍵 𓍶 𓍷 𓍸 𓍹 𓍺 𓍻 𓍼 𓍽 𓍾 𓍿 𓎀 𓎁 𓎂 𓎃 𓎄 𓎅 𓎆 𓎇 𓎈 𓎉 𓎊 𓎋 𓎌 𓎍 𓎎 𓎏 𓎐 𓎑 𓎒 𓎓 𓎔 𓎕 𓎖 𓎗 𓎘 𓎙 𓎚 𓎛 𓎜 𓎝 𓎞 𓎟 𓎠 𓎡 𓎢 𓎣 𓎤 𓎥 𓎦 𓎧 𓎨 𓎩 𓎪 𓎫 𓎬 𓎭 𓎮 𓎯 𓎰 𓎱 𓎲 𓎳 𓎴 𓎵 𓎶 𓎷 𓎸 𓎹 𓎺 𓎻 𓎼 𓎽 𓎾 𓎿 𓏀 𓏁 𓏂 𓏃 𓏄 𓏅 𓏆 𓏇 𓏈 𓏉 𓏊 𓏋 𓏌 𓏍 𓏎 𓏏 𓏐 𓏑 𓏒 𓏓 𓏔 𓏕 𓏖 𓏗 𓏘 𓏙 𓏚 𓏛 𓏜 𓏝 𓏞 𓏟 𓏠 𓏡 𓏢 𓏣 𓏤 𓏥 𓏦 𓏧 𓏨 𓏩 𓏪 𓏫 𓏬 𓏭 𓏮 𓏯 𓏰 𓏱 𓏲 𓏳 𓏴 𓏵 𓏶 𓏷 𓏸 𓏹 𓏺 𓏻 𓏼 𓏽 𓏾 𓏿 𓐀 𓐁 𓐂 𓐃 𓐄 𓐅 𓐆 𓐇 𓐈 𓐉 𓐊 𓐋 𓐌 𓐍 𓐎 𓐏 𓐐 𓐑 𓐒 𓐓 𓐔 𓐕 𓐖 𓐗 𓐘 𓐙 𓐚 𓐛 𓐜 𓐝 𓐞 𓐟]],
+		}
+		for i = 1, 255 do 
+			local char = string.char(i)
+			bad_keys[char] = char
+		end
+		
+		print(PREFIX .. `UTF-8 test ⏳... (Will take around {AUTO_SAVE_PERIOD} seconds)`)
+		
+		local key = UniqueKey(7)
+		
+		local profile = Store1:StartSessionAsync(key)
+		for _, bad_key in bad_keys do
+			profile.Data[bad_key] = bad_key
+		end
+
+		profile.OnAfterSave:Wait()
+
+		--/Verify if the data is valid
+		local function verify_json(str: string): boolean
+			return (pcall(game:GetService("HttpService").JSONEncode, game:GetService("HttpService"), str))
+		end
+
+		--/Check if the data is valid
+		local is_pass = true
+		for cleaned_key, cleaned_value in pairs(profile.Data) do
+
+			--/Make sure the key and value are valid
+			if (typeof(cleaned_key) == "string" and not verify_json(cleaned_key)) or (typeof(cleaned_value) == "string" and not verify_json(cleaned_value)) then
+				is_pass = false
+			end
+			
+		end
+
+		profile:EndSession()
+
+		TestPass(`UTF-8 test`, is_pass)
+		
+	end
 	
 	-- Cache test:
 	


### PR DESCRIPTION
As shown in [this gist](https://gist.github.com/TheGreatSageEqualToHeaven/e0e1dc2698307c93f6013b9825705899) and [this dev-forum post](https://devforum.roblox.com/t/datastoreservice-method-to-verify-if-a-value-is-saveable-bring-more-attention-to-malicious-strings/2658551), there is a Datastore vulnerability where if a player were to somehow send a malicious string and it not be handled by the developer it would cause the player to not be able to save their data and when they rejoin it would roll-back to before they did an action. This is very bad since can cause dupes if the developer doesn't account for these. I made this solution for my game and want to spread the word and my *pretty ugly* fix.

Credits:
Edited TheGreatSageEqualToHeaven's [is_valid_utf8](https://devforum.roblox.com/t/datastoreservice-method-to-verify-if-a-value-is-saveable-bring-more-attention-to-malicious-strings/2658551/7) function to sanatize.

Happy coding,
SpencerDevv