### PR TITLE
fix(types): StartSessionAsync's params type being incorrect

### DIFF
--- a/ProfileStore.luau
+++ b/ProfileStore.luau
@@ -1001,10 +1001,10 @@ export type VersionQuery<T> = {
 
 type ProfileStoreStandard<T> = {
 	Name: string,
-	StartSessionAsync: (self: any, profile_key: string, params: {Steal: boolean?}) -> (Profile<T>?),
+    StartSessionAsync: (self: any, profile_key: string, params: {Cancel: (() -> boolean?)?, Steal: boolean?}?) -> (Profile<T>?),
 	MessageAsync: (self: any, profile_key: string, message: JSONAcceptable) -> (boolean),
 	GetAsync: (self: any, profile_key: string, version: string?) -> (Profile<T>?),
-	VersionQuery: (self: any, profile_key: string, sort_direction: Enum.SortDirection?, min_date: DateTime | number | nil, max_date: DateTime | number | nil) -> (VersionQuery<T>),
+    VersionQuery: (self: any, profile_key: string, sort_direction: Enum.SortDirection?, min_date: (DateTime | number)?, max_date: (DateTime | number)?) -> (VersionQuery<T>),
 	RemoveAsync: (self: any, profile_key: string) -> (boolean),
 }
 


### PR DESCRIPTION
StartSessionAsync method has `Cancel` field missing in `params`, as well as it being required